### PR TITLE
fix: return full results from queries that run longer

### DIFF
--- a/hive/operation.go
+++ b/hive/operation.go
@@ -5,7 +5,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/sclgo/impala-go/services/cli_service"
+)
+
+const (
+	initialBackoff = 100 * time.Millisecond
+	maxBackoff     = time.Second
 )
 
 // Operation represents hive operation
@@ -70,11 +76,12 @@ func (op *Operation) FetchResults(ctx context.Context, schema *TableSchema) (*Re
 	}
 
 	rs := ResultSet{
-		idx:     0,
-		length:  length(resp.Results),
-		result:  resp.Results,
-		more:    resp.GetHasMoreRows(),
-		schema:  schema,
+		idx:    0,
+		length: length(resp.Results),
+		result: resp.Results,
+		more:   resp.GetHasMoreRows(),
+		schema: schema,
+		// TODO align query context handling with database/sql practices (Github #14)
 		fetchfn: func() (*cli_service.TFetchResultsResp, error) { return fetch(ctx, op) },
 	}
 
@@ -95,16 +102,17 @@ func (op *Operation) GetState(ctx context.Context) (cli_service.TOperationState,
 	return resp.GetOperationState(), nil
 }
 
+// WaitToFinish waits for the operation to reach a FINISHED state
+// Returns error if the operation fails or the context is cancelled.
 func (op *Operation) WaitToFinish(ctx context.Context) error {
-	duration := 100 * time.Millisecond
+	duration := initialBackoff
 	opState, err := op.GetState(ctx)
 	for err == nil && opState != cli_service.TOperationState_FINISHED_STATE {
 		sleep(ctx, duration)
 		opState, err = op.GetState(ctx)
-		duration *= 2
-		if duration > time.Second {
-			duration = time.Second
-		}
+		// GetState should have returned an error if ctx.Err() but just in case
+		err = lo.CoalesceOrEmpty(err, ctx.Err())
+		duration = nextDuration(duration)
 	}
 	return err
 }
@@ -117,16 +125,39 @@ func fetch(ctx context.Context, op *Operation) (*cli_service.TFetchResultsResp, 
 
 	op.hive.log.Printf("fetch results for operation: %v", guid(op.h.OperationId.GUID))
 
-	resp, err := op.hive.client.FetchResults(ctx, &req)
-	if err != nil {
-		return nil, err
-	}
-	if err := checkStatus(resp); err != nil {
-		return nil, err
+	var duration time.Duration
+	fetchStatus := cli_service.TStatusCode_STILL_EXECUTING_STATUS
+	resp := &cli_service.TFetchResultsResp{}
+	for fetchStatus == cli_service.TStatusCode_STILL_EXECUTING_STATUS && ctx.Err() == nil {
+		// It is questionable if we need to back-off (sleep) in this case
+		// impala-shell doesn't - https://github.com/apache/impala/blob/1f35747/shell/impala_client.py#L958
+		if duration == 0 {
+			duration = initialBackoff
+		} else {
+			sleep(ctx, duration)
+			duration = nextDuration(duration)
+		}
+		var err error
+		resp, err = op.hive.client.FetchResults(ctx, &req)
+		if err != nil {
+			return nil, err
+		}
+		if err = checkStatus(resp); err != nil {
+			return nil, err
+		}
+		fetchStatus = resp.GetStatus().StatusCode
 	}
 
 	op.hive.log.Printf("results: %v", resp.Results)
-	return resp, nil
+	return resp, ctx.Err()
+}
+
+func nextDuration(duration time.Duration) time.Duration {
+	duration *= 2
+	if duration > maxBackoff {
+		duration = maxBackoff
+	}
+	return duration
 }
 
 // Close closes operation
@@ -146,9 +177,10 @@ func (op *Operation) Close(ctx context.Context) error {
 	return nil
 }
 
+// sleep sleeps in a context aware way
 func sleep(ctx context.Context, d time.Duration) {
 	select {
 	case <-ctx.Done():
-	case <-time.After(d): // before Go 1.23, this used to leak memory but not anymore
+	case <-time.After(d): // before Go 1.23, this risked leaking memory but not anymore
 	}
 }

--- a/hive/operation_test.go
+++ b/hive/operation_test.go
@@ -38,8 +38,5 @@ type opThriftClient struct {
 
 func (c *opThriftClient) GetOperationStatus(ctx context.Context, _ *cli_service.TGetOperationStatusReq) (*cli_service.TGetOperationStatusResp, error) {
 	c.called = true
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	return &cli_service.TGetOperationStatusResp{}, nil
+	return &cli_service.TGetOperationStatusResp{}, ctx.Err()
 }

--- a/hive/result_set_test.go
+++ b/hive/result_set_test.go
@@ -1,0 +1,78 @@
+package hive
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sclgo/impala-go/services/cli_service"
+)
+
+func TestResultSet(t *testing.T) {
+	t.Run("fetch 0 but has more", func(t *testing.T) {
+		r := &results{
+			data: []any{
+				[]*cli_service.TColumn{},
+				[]*cli_service.TColumn{
+					{
+						StringVal: &cli_service.TStringColumn{
+							Nulls:  []byte{0},
+							Values: []string{"hello"},
+						},
+					},
+				},
+			},
+		}
+		rs := ResultSet{
+			idx:     0,
+			length:  0,
+			fetchfn: r.fetch,
+			more:    true,
+			schema: &TableSchema{
+				Columns: []*ColDesc{
+					{
+						DatabaseTypeName: "VARCHAR",
+					},
+				},
+			},
+		}
+		data := make([]driver.Value, 1)
+		err := rs.Next(data)
+		require.NoError(t, err)
+		require.EqualValues(t, "hello", data[0])
+		err = rs.Next(data)
+		require.Equal(t, io.EOF, err)
+	})
+}
+
+type results struct {
+	idx  int
+	data []any
+}
+
+func (r *results) fetch() (*cli_service.TFetchResultsResp, error) {
+	dataPoint := r.data[r.idx]
+	r.idx++
+	switch d := dataPoint.(type) {
+	case error:
+		return nil, d
+	case *cli_service.TFetchResultsResp:
+		return d, nil
+	case []*cli_service.TColumn:
+		return &cli_service.TFetchResultsResp{
+			Status:      &cli_service.TStatus{},
+			HasMoreRows: lo.ToPtr(r.idx < len(r.data)),
+			Results: &cli_service.TRowSet{
+				StartRowOffset: int64(r.idx - 1),
+				Columns:        d,
+			},
+		}, nil
+	default:
+		panic(fmt.Sprintf("unexpected data type: %T", dataPoint))
+	}
+
+}

--- a/statement_test.go
+++ b/statement_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestStatement(t *testing.T) {
+func TestStatement_ValueReplacement(t *testing.T) {
 	tests := []struct {
 		stmt   string
 		args   []driver.NamedValue


### PR DESCRIPTION
return full results from queries that run longer than FETCH_ROWS_TIMEOUT_MS

Handle STILL_EXECUTING and other cases.

Closes #10