### PR TITLE
tests: include integration tests in coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
     - name: Send coverage
       env:
         COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-      run: go run github.com/mattn/goveralls@latest -coverprofile=covprofile -service=github
+      run: go run github.com/mattn/goveralls@latest -coverprofile=./coverage/covprofile -service=github
 
     - name: Archive code coverage results
       uses: actions/upload-artifact@v4
       with:
         name: code-coverage-report
-        path: coverage.html
+        path: ./coverage/coverage.html
 
   post-merge:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,4 @@ _testmain.go
 *.prof
 
 vendor/
-/coverage.html
-/covprofile
+coverage/

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,11 @@ test-cli: usql
 	./usql -c "\drivers" | grep impala
 
 test:
-	go test -race -covermode atomic -coverprofile=covprofile -v -vet=all `exec go list ./... | grep -v "./internal/generated"`
-	go tool cover -html=covprofile -o coverage.html
+	mkdir -p coverage/covdata
+	# Use the new binary format to ensure integration tests and cross-package calls are counted towards coverage
+	# https://go.dev/blog/integration-test-coverage
+	go test -race -cover -v -vet=all `exec go list ./... | grep -v "./internal/generated"` -args -test.gocoverdir="${PWD}/coverage/covdata"
+	go tool covdata percent -i=./coverage/covdata
+	# Convert to old text format for coveralls upload
+	go tool covdata textfmt -i=./coverage/covdata -o ./coverage/covprofile
+	go tool cover -html=./coverage/covprofile -o ./coverage/coverage.html


### PR DESCRIPTION
Use the Go 1.20 coverage features to make sure cross-package calls are counted in coverage. That includes integration tests. Based on https://dustinspecker.com/posts/go-combined-unit-integration-code-coverage/

Part of #19  .