### PR TITLE
tests: use -coverpkg to further improve coverage accuracy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,14 @@ usql:
 test-cli: usql
 	./usql -c "\drivers" | grep impala
 
+PKGS=$(shell exec go list ./... | grep -v "./internal/generated")
+PKGS_LST=$(shell echo ${PKGS} | tr ' ' ',')
 test:
 	mkdir -p coverage/covdata
 	# Use the new binary format to ensure integration tests and cross-package calls are counted towards coverage
 	# https://go.dev/blog/integration-test-coverage
-	go test -race -cover -v -vet=all `exec go list ./... | grep -v "./internal/generated"` -args -test.gocoverdir="${PWD}/coverage/covdata"
+	# -coverpkg can't be ./... because that will include generated code in the stats
+	go test -race -cover -coverpkg "${PKGS_LST}" -v -vet=all ${PKGS} -args -test.gocoverdir="${PWD}/coverage/covdata"
 	go tool covdata percent -i=./coverage/covdata
 	# Convert to old text format for coveralls upload
 	go tool covdata textfmt -i=./coverage/covdata -o ./coverage/covprofile


### PR DESCRIPTION
-coverpkgleads to worse reporting while the tests are being executed but may make overall reporting more accurate - include all cross-package calls but ignore generated code.