### PR TITLE
tests: enable running example with compose spec

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -1,0 +1,1 @@
+IMPALA_QUICKSTART_IMAGE_PREFIX:apache/impala:4.4.1-

--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -65,7 +65,7 @@ services:
       - ./quickstart_conf:/opt/impala/conf:ro
     networks:
       - quickstart-network
-  impalad-1:
+  impalad:
     image: ${IMPALA_QUICKSTART_IMAGE_PREFIX:-}impalad_coord_exec
     depends_on:
       - statestored
@@ -85,15 +85,22 @@ services:
       - "-mt_dop_auto_fallback=true"
       - "-default_query_options=mt_dop=4,default_file_format=parquet,default_transactional_type=insert_only"
       - "-mem_limit=4gb"
-      - "-ssl_server_certificate=/ssl/localhost.crt"
-      - "-ssl_private_key=/ssl/localhost.key"
+    #      - "-ssl_server_certificate=/ssl/localhost.crt"
+    #      - "-ssl_private_key=/ssl/localhost.key"
     environment:
       # Keep the Java heap small to preserve memory for query execution.
       - JAVA_TOOL_OPTIONS="-Xmx1g"
     volumes:
       - impala-quickstart-warehouse:/user/hive/warehouse
       - ./quickstart_conf:/opt/impala/conf:ro
-      - ./testssl:/ssl:ro
+    #      - ./testssl:/ssl:ro
+    networks:
+      - quickstart-network
+  healthcheck:
+    depends_on:
+      - impalad
+    build:
+      context: healthcheck
     networks:
       - quickstart-network
 volumes:

--- a/compose/e2e.sh
+++ b/compose/e2e.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -ex
+
+docker compose down -v
+docker compose up --wait
+go run ../examples/enumerateDB.go

--- a/compose/healthcheck/Dockerfile
+++ b/compose/healthcheck/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine/curl:8.11.1
+HEALTHCHECK \
+    CMD curl -f http://impalad:25000 || exit 1
+ENTRYPOINT []
+# Lots of other options for "run indefinitely" did not respond to SIGTERM
+# sleep, tail -f /dev/null, & wait etc
+CMD ["sh", "-c", "trap \"exit\" TERM; while true; do sleep 1; done"]


### PR DESCRIPTION
Improve the docker compose setup so it can be used to run the example program
enumerateDB. This includes:
- a new healthcheck container which makes "docker compose up --wait" complete
  exactly after Impala is up
- disabled TLS in the compose spec - we stopped using the compose spec for integration tests
  a few commits ago
- rename the regular compose spec to compose.yml so we don't have to specify the spec file every time
- added e2e.sh which tests the example program and the spec as a single command

Closes #45 
