### PR TITLE
feat: return specific error when authentication with password fails

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -21,10 +21,21 @@ import (
 	"github.com/sclgo/impala-go/internal/sasl"
 )
 
+// Sentinel errors that don't carry instance information
+
 var (
 	// ErrNotSupported means this operation is not supported by impala driver
 	ErrNotSupported = isql.ErrNotSupported
 )
+
+// The following errors carry instance information so they are types, instead of sentinel values.
+
+// UserPassAuthError indicates that the provided username and password combination is not correct.
+// The error message documents the username that was used. errors.Unwrap() returns
+// the underlying error that was interpreted as auth. failure.
+// This error will not be top-level in the chain - earlier errors in the chain
+// reflect the process during which the auth. error happened.
+type UserPassAuthError = sasl.UserPassAuthError
 
 const (
 	badDSNErrorPrefix = "impala: bad DSN: "

--- a/internal/isql/connection_test.go
+++ b/internal/isql/connection_test.go
@@ -248,12 +248,20 @@ func runImpala4SpecificTests(t *testing.T, dsn string) {
 	t.Run("bad password", func(t *testing.T) {
 		badPassDsn, err := url.Parse(dsn)
 		require.NoError(t, err)
-		badPassDsn.User = url.UserPassword("wrong", "password")
-		builtInCertsDb := fi.NoError(sql.Open("impala", badPassDsn.String())).Require(t)
-		defer fi.NoErrorF(builtInCertsDb.Close, t)
-		err = builtInCertsDb.Ping()
-		expectedErrorType := &impala.UserPassAuthError{}
-		require.ErrorAs(t, err, &expectedErrorType)
+		for _, usr := range []*url.Userinfo{
+			url.User("nopass"),
+			url.UserPassword("wrong", "password"),
+		} {
+			t.Run(usr.Username(), func(t *testing.T) {
+				badPassDsn.User = usr
+				builtInCertsDb := fi.NoError(sql.Open("impala", badPassDsn.String())).Require(t)
+				defer fi.NoErrorF(builtInCertsDb.Close, t)
+				err = builtInCertsDb.Ping()
+				var expectedErrorType *impala.AuthError
+				require.ErrorAs(t, err, &expectedErrorType)
+				require.ErrorContains(t, err, usr.Username())
+			})
+		}
 	})
 }
 

--- a/internal/isql/connection_test.go
+++ b/internal/isql/connection_test.go
@@ -244,6 +244,17 @@ func runImpala4SpecificTests(t *testing.T, dsn string) {
 		expectedErrorType := &tls.CertificateVerificationError{}
 		require.ErrorAs(t, err, &expectedErrorType)
 	})
+
+	t.Run("bad password", func(t *testing.T) {
+		badPassDsn, err := url.Parse(dsn)
+		require.NoError(t, err)
+		badPassDsn.User = url.UserPassword("wrong", "password")
+		builtInCertsDb := fi.NoError(sql.Open("impala", badPassDsn.String())).Require(t)
+		defer fi.NoErrorF(builtInCertsDb.Close, t)
+		err = builtInCertsDb.Ping()
+		expectedErrorType := &impala.UserPassAuthError{}
+		require.ErrorAs(t, err, &expectedErrorType)
+	})
 }
 
 func startImpala3(t *testing.T) string {

--- a/internal/sasl/client.go
+++ b/internal/sasl/client.go
@@ -29,11 +29,16 @@ func (c *client) Step(challenge []byte) ([]byte, bool, error) {
 	return c.m.Step(challenge)
 }
 
+func (c *client) InterpretReceiveEOF(transportError error) error {
+	return c.m.InterpretReceiveEOF(transportError)
+}
+
 func (c *client) Free() {}
 
 type mech interface {
 	Start() (mech string, initial []byte, done bool, err error)
 	Step(challenge []byte) (response []byte, done bool, err error)
+	InterpretReceiveEOF(transportError error) error
 }
 
 type client struct {

--- a/internal/sasl/plain.go
+++ b/internal/sasl/plain.go
@@ -16,3 +16,10 @@ func (m *plain) Start() (string, []byte, bool, error) {
 func (m *plain) Step(_ []byte) ([]byte, bool, error) {
 	return nil, false, ErrUnexpectedServerChallenge
 }
+
+func (m *plain) InterpretReceiveEOF(transportError error) error {
+	return &UserPassAuthError{
+		username:       m.opts.Username,
+		transportError: transportError,
+	}
+}

--- a/internal/sasl/plain.go
+++ b/internal/sasl/plain.go
@@ -18,7 +18,7 @@ func (m *plain) Step(_ []byte) ([]byte, bool, error) {
 }
 
 func (m *plain) InterpretReceiveEOF(transportError error) error {
-	return &UserPassAuthError{
+	return &AuthError{
 		username:       m.opts.Username,
 		transportError: transportError,
 	}

--- a/internal/sasl/sasl.go
+++ b/internal/sasl/sasl.go
@@ -1,6 +1,8 @@
 package sasl
 
-import "errors"
+import (
+	"errors"
+)
 
 // Common SASL errors.
 var (
@@ -29,4 +31,5 @@ type Client interface {
 	Start(mechlist []string) (mech string, initial []byte, done bool, err error)
 	Step(challenge []byte) (response []byte, done bool, err error)
 	Free()
+	InterpretReceiveEOF(transportError error) error
 }

--- a/internal/sasl/transport.go
+++ b/internal/sasl/transport.go
@@ -11,24 +11,24 @@ import (
 	"github.com/apache/thrift/lib/go/thrift"
 )
 
-type UserPassAuthError struct {
+type AuthError struct {
 	username       string
 	transportError error
 }
 
 // Error implements error
-func (e *UserPassAuthError) Error() string {
+func (e *AuthError) Error() string {
 	// message does not start with "impala: " because this error is expected to be wrapped
 	// in a chain, reflecting the process during which the auth. error occurred.
 	return fmt.Sprintf("authentication failed for user %s", e.username)
 }
 
 // Unwrap implements support for error.Is / As
-func (e *UserPassAuthError) Unwrap() error {
+func (e *AuthError) Unwrap() error {
 	return e.transportError
 }
 
-var _ error = (*UserPassAuthError)(nil)
+var _ error = (*AuthError)(nil)
 
 type TSaslTransport struct {
 	rbuf *bytes.Buffer

--- a/internal/sasl/transport.go
+++ b/internal/sasl/transport.go
@@ -4,11 +4,31 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 
 	"github.com/apache/thrift/lib/go/thrift"
 )
+
+type UserPassAuthError struct {
+	username       string
+	transportError error
+}
+
+// Error implements error
+func (e *UserPassAuthError) Error() string {
+	// message does not start with "impala: " because this error is expected to be wrapped
+	// in a chain, reflecting the process during which the auth. error occurred.
+	return fmt.Sprintf("authentication failed for user %s", e.username)
+}
+
+// Unwrap implements support for error.Is / As
+func (e *UserPassAuthError) Unwrap() error {
+	return e.transportError
+}
+
+var _ error = (*UserPassAuthError)(nil)
 
 type TSaslTransport struct {
 	rbuf *bytes.Buffer
@@ -60,16 +80,16 @@ func (t *TSaslTransport) Open() error {
 	}
 
 	if err := t.negotiationSend(StatusStart, []byte(mech)); err != nil {
-		return fmt.Errorf("sasl: negotiation failed. %v", err)
+		return fmt.Errorf("sasl: negotiation failed. %w", err)
 	}
 	if err := t.negotiationSend(StatusOK, initial); err != nil {
-		return fmt.Errorf("sasl: negotiation failed. %v", err)
+		return fmt.Errorf("sasl: negotiation failed. %w", err)
 	}
 
 	for {
 		status, challenge, err := t.receive()
 		if err != nil {
-			return fmt.Errorf("sasl: negotiation failed. %v", err)
+			return fmt.Errorf("sasl: negotiation failed. %w", err)
 		}
 
 		if status != StatusOK && status != StatusComplete {
@@ -82,10 +102,10 @@ func (t *TSaslTransport) Open() error {
 
 		payload, _, err := t.sasl.Step(challenge)
 		if err != nil {
-			return fmt.Errorf("sasl: negotiation failed. %v", err)
+			return fmt.Errorf("sasl: negotiation failed. %w", err)
 		}
 		if err := t.negotiationSend(StatusOK, payload); err != nil {
-			return fmt.Errorf("sasl: negotiation failed. %v", err)
+			return fmt.Errorf("sasl: negotiation failed. %w", err)
 		}
 
 	}
@@ -182,6 +202,12 @@ func (t *TSaslTransport) receive() (Status, []byte, error) {
 	header := make([]byte, 5)
 	_, err := t.trans.Read(header)
 	if err != nil {
+		var transportError thrift.TTransportException
+		if errors.As(err, &transportError) {
+			if transportError.TypeId() == thrift.END_OF_FILE {
+				return 0, nil, t.sasl.InterpretReceiveEOF(err)
+			}
+		}
 		return 0, nil, err
 	}
 	return Status(header[0]), header[1:], nil

--- a/internal/sasl/transport.go
+++ b/internal/sasl/transport.go
@@ -80,7 +80,7 @@ func (t *TSaslTransport) Open() error {
 	}
 
 	if err := t.negotiationSend(StatusStart, []byte(mech)); err != nil {
-		return fmt.Errorf("sasl: negotiation failed. %w", err)
+return fmt.Errorf("sasl: negotiation failed for mech %s. %w", mech, err)
 	}
 	if err := t.negotiationSend(StatusOK, initial); err != nil {
 		return fmt.Errorf("sasl: negotiation failed. %w", err)

--- a/internal/sasl/transport.go
+++ b/internal/sasl/transport.go
@@ -83,13 +83,13 @@ func (t *TSaslTransport) Open() error {
 return fmt.Errorf("sasl: negotiation failed for mech %s. %w", mech, err)
 	}
 	if err := t.negotiationSend(StatusOK, initial); err != nil {
-		return fmt.Errorf("sasl: negotiation failed. %w", err)
+return fmt.Errorf("sasl: negotiation failed for mech %s. %w", mech, err)
 	}
 
 	for {
 		status, challenge, err := t.receive()
 		if err != nil {
-			return fmt.Errorf("sasl: negotiation failed. %w", err)
+return fmt.Errorf("sasl: negotiation failed for mech %s. %w", mech, err)
 		}
 
 		if status != StatusOK && status != StatusComplete {
@@ -102,10 +102,10 @@ return fmt.Errorf("sasl: negotiation failed for mech %s. %w", mech, err)
 
 		payload, _, err := t.sasl.Step(challenge)
 		if err != nil {
-			return fmt.Errorf("sasl: negotiation failed. %w", err)
+return fmt.Errorf("sasl: negotiation failed for mech %s. %w", mech, err)
 		}
 		if err := t.negotiationSend(StatusOK, payload); err != nil {
-			return fmt.Errorf("sasl: negotiation failed. %w", err)
+return fmt.Errorf("sasl: negotiation failed for mech %s. %w", mech, err)
 		}
 
 	}


### PR DESCRIPTION
Authentication failure may be handled by the caller e.g. by asking the
user to update the password like in usql, so it is valuable to
expose a way to identify such failures in the API.

The implementation avoids exposing thrift to the sasl package.
sasl implementation layers will likely be refactored and simplified
after #29 .