### PR TITLE
tests: update test-cli after the inclusion of impala-go in usql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ enumerateDB
 compose/notebooks/.ipynb_checkpoints/
 compose/jupyter_conf/lab
 compose/jupyter_conf/serverconfig/
+/usql

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ thrift:
 .PHONY: cli
 cli: usql
 
-usql:
-	go run github.com/sclgo/usqlgen@v0.1.1 -v build --import github.com/sclgo/impala-go
+usql: Makefile
+	go run github.com/sclgo/usqlgen@v0.3.0 -v build --get github.com/sclgo/impala-go@$(shell git branch --show-current || echo master) -- -tags impala
 
 short-test:
 	go test -short -v ./...


### PR DESCRIPTION
Now that impala-go is in usql, we can test if the current remote branch works with latest usql

Testing Done: make test-cli locally