### PR TITLE
feat: support for decimal, column length, precision, scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,21 @@ func main() {
 
 Check out also [an open data end-to-end demo](compose/README.md).
 
+## Data types
+
+[Impala data types](https://impala.apache.org/docs/build/html/topics/impala_datatypes.html)
+are mapped to Go types as expected, with the following exceptions:
+
+* Complex types - MAP, STRUCT, ARRAY - are not supported. Impala itself has limited support for those.
+  As a workaround, select individual fields or flatten such values within select statements.
+* Decimals are converted to strings
+  by [the Impala server API](https://github.com/apache/impala/blob/c5a0ec8/common/thrift/hive-1-api/TCLIService.thrift#L327).
+  Either parse the decimal value after `Row.Scan`,
+  or use a custom [sql.Scanner](https://pkg.go.dev/database/sql#Scanner) implementation
+  in `Row.Scan` e.g. `Decimal` from [github.com/cockroachdb/apd](https://github.com/cockroachdb/apd).
+  Note that the processing of `sql.Scanner` within `Row.Scan` is a feature of the `database/sql` package,
+  and not the driver. The `ScanType` of `DECIMAL` columns is `string`, while the ColumnTy
+
 ## Support
 
 The library is actively tested with Impala 4.4 and 3.4.

--- a/driver.go
+++ b/driver.go
@@ -67,6 +67,9 @@ func parseURI(uri string) (*Options, error) {
 		return nil, err
 	}
 
+	// #21, https and http will be supported in the future for http transport
+	// transport=http(s) will also be supported for usql/dburl compatibility
+
 	if u.Scheme != "impala" {
 		return nil, fmt.Errorf("scheme %s not recognized", u.Scheme)
 	}

--- a/internal/isql/rows.go
+++ b/internal/isql/rows.go
@@ -14,12 +14,12 @@ type Rows struct {
 	closefn func() error
 }
 
-// Close closes rows iterator
+// Close closes rows iterator. Implements [driver.Rows].
 func (r *Rows) Close() error {
 	return r.closefn()
 }
 
-// Columns returns the names of the columns
+// Columns returns the names of the columns. Implements [driver.Rows].
 func (r *Rows) Columns() []string {
 	var cols []string
 	for _, col := range r.schema.Columns {
@@ -28,17 +28,36 @@ func (r *Rows) Columns() []string {
 	return cols
 }
 
-// ColumnTypeScanType returns column's native type
+// ColumnTypeScanType returns column's native type.
+// Implements [driver.RowsColumnTypeScanType]
 func (r *Rows) ColumnTypeScanType(index int) reflect.Type {
 	return r.schema.Columns[index].ScanType
 }
 
-// ColumnTypeDatabaseTypeName returns column's database type name
+// ColumnTypeDatabaseTypeName returns column's database type name.
+// Implements [driver.RowsColumnTypeDatabaseTypeName]
 func (r *Rows) ColumnTypeDatabaseTypeName(index int) string {
 	return r.schema.Columns[index].DatabaseTypeName
 }
 
-// Next prepares next row for scanning
+// ColumnTypeNullable implements [driver.RowsColumnTypeNullable]
+func (r *Rows) ColumnTypeNullable(index int) (nullable, ok bool) {
+	return !r.schema.Columns[index].NotNull, true
+}
+
+// ColumnTypePrecisionScale implements [driver.RowsColumnTypePrecisionScale]
+func (r *Rows) ColumnTypePrecisionScale(index int) (precision, scale int64, ok bool) {
+	colDesc := r.schema.Columns[index]
+	return colDesc.Precision, colDesc.Scale, colDesc.HasPrecisionScale
+}
+
+// ColumnTypeLength implements [driver.RowsColumnTypeLength]
+func (r *Rows) ColumnTypeLength(index int) (length int64, ok bool) {
+	colDesc := r.schema.Columns[index]
+	return colDesc.Length, colDesc.HasLength
+}
+
+// Next prepares next row for scanning. Implements [driver.Rows].
 func (r *Rows) Next(dest []driver.Value) error {
 	return r.rs.Next(dest)
 }


### PR DESCRIPTION
Implements supports for reporting column length, precision and scale,
extracting them from the Thirft API type qualifiers and publishing them via
the database/sql API. 

Documents and tests support for Decimal values.