### PR TITLE
fix: return ErrBadConn in more cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ Also, you can bypass the string-based data source name by using sql.OpenDB:
   db, err := sql.OpenDB(connector)
 ```
 
+Impala supports numerous other session options which can be configured with the 
+[SET statement](https://impala.apache.org/docs/build/html/topics/impala_set.html).
+`mem-limit` and `query-timeout` are the only two such options the driver supports as part of the DSN.
+Those DSN fields for those are an exception for backwards compatibility. The preferred way to set any
+session option is issuing SET statements to a SQL connection. Users may find it useful to wrap the 
+`driver.Connector` returned by `impala.NewConnector` so that a set of session options are automatically applied to
+all created connections.
 
 ## CLI
 

--- a/compose/e2e.sh
+++ b/compose/e2e.sh
@@ -4,8 +4,11 @@ set -ex
 docker compose down -v
 docker compose up --wait
 go run ../examples/enumerateDB.go
-[ -f usql ] || go run github.com/sclgo/usqlgen@latest build --import github.com/sclgo/impala-go -- -tags no_base
+
+# if impala-go from current source is needed, build usql beforehand
+[ -f usql ] || go run github.com/sclgo/usqlgen@latest build -- -tags impala
+
 docker compose exec healthcheck cp /combinedjar/esri-gis.jar /user/hive/warehouse
-./usql impala:impala://localhost -f opendata/gis.sql
-./usql impala:impala://localhost -f opendata/create_table_latest.sql
-./usql impala:impala://localhost -f opendata/query.sql
+./usql impala://localhost -f opendata/gis.sql
+./usql impala://localhost -f opendata/create_table_latest.sql
+./usql impala://localhost -f opendata/query.sql

--- a/compose/healthcheck/Dockerfile
+++ b/compose/healthcheck/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:oracular
+FROM ubuntu:24.04
 RUN apt-get update && apt-get install -y zip unzip curl
 ADD https://github.com/Esri/gis-tools-for-hadoop/raw/c5d4942d4e/samples/lib/esri-geometry-api.jar /esri-geometry-api.jar
 ADD https://github.com/Esri/gis-tools-for-hadoop/raw/c5d4942d4e/samples/lib/spatial-sdk-hadoop.jar /spatial-sdk-hadoop.jar

--- a/functest/connection_test.go
+++ b/functest/connection_test.go
@@ -113,6 +113,10 @@ func TestIntegration_Restart(t *testing.T) {
 	db := fi.NoError(sql.Open("impala", dsn)).Require(t)
 	defer helperr.CloseQuietly(db)
 
+	db2 := fi.NoError(sql.Open("impala", dsn)).Require(t)
+	defer helperr.CloseQuietly(db2)
+	db2.SetMaxIdleConns(1)
+
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
 
@@ -121,8 +125,11 @@ func TestIntegration_Restart(t *testing.T) {
 	err = conn.PingContext(ctx)
 	require.NoError(t, err)
 
-	// ensure there is an open connection in the pool
+	// ensure there is an open connection in both pools; conn is also open but out of the pool
 	err = db.PingContext(ctx)
+	require.NoError(t, err)
+
+	err = db2.PingContext(ctx)
 	require.NoError(t, err)
 
 	err = c.Stop(ctx, lo.ToPtr(1*time.Minute))
@@ -139,9 +146,14 @@ func TestIntegration_Restart(t *testing.T) {
 		return perr == nil
 	}, 2*time.Minute, 2*time.Second)
 
+	// the conn that we took out of the pool before restart should still be bad even after Impala is back up
 	err = conn.PingContext(ctx)
-	require.Error(t, err)
-	// require.ErrorIs(t, err, driver.ErrBadConn) hmmm?
+	require.ErrorIs(t, err, driver.ErrBadConn)
+
+	// Ping on the second pool should succeed even though that pool contains connections that are broken
+	// because of successful retry inside database/sql
+	err = db2.PingContext(ctx)
+	require.NoError(t, err)
 }
 
 func runSuite(t *testing.T, dsn string) {
@@ -175,6 +187,24 @@ func runHappyCases(t *testing.T, db *sql.DB) {
 	t.Run("decimal support", func(t *testing.T) {
 		testDecimal(t, db)
 	})
+	t.Run("set", func(t *testing.T) {
+		testSet(t, db)
+	})
+}
+
+func testSet(t *testing.T, db *sql.DB) {
+	res, err := db.Query("SET")
+	require.NoError(t, err)
+	defer helperr.CloseQuietly(res)
+	cnt := 0
+	for res.Next() {
+		var key, value, configType string
+		require.NoError(t, res.Scan(&key, &value, &configType))
+		cnt++
+	}
+	require.NoError(t, res.Err())
+	require.Greater(t, cnt, 10)
+	require.NoError(t, res.Close())
 }
 
 func runErrorCases(t *testing.T, db *sql.DB) {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/sclgo/impala-go
 
-go 1.24.0
-
-toolchain go1.25.9
+go 1.25.9
 
 require (
 	github.com/apache/thrift v0.22.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/sclgo/impala-go
 
-go 1.25.9
+go 1.24.0
+
+toolchain go1.25.9
 
 require (
 	github.com/apache/thrift v0.22.0

--- a/internal/hive/client.go
+++ b/internal/hive/client.go
@@ -54,7 +54,7 @@ func (c *Client) OpenSession(ctx context.Context) (*Session, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := checkStatus(resp); err != nil {
+	if err = checkStatus(resp); err != nil {
 		return nil, err
 	}
 

--- a/internal/hive/session.go
+++ b/internal/hive/session.go
@@ -23,7 +23,7 @@ func (s *Session) Ping(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := s.checkStatus(resp); err != nil {
+	if err = s.checkStatus(resp); err != nil {
 		return err
 	}
 
@@ -42,7 +42,7 @@ func (s *Session) ExecuteStatement(ctx context.Context, stmt string) (*Operation
 	if err != nil {
 		return nil, err
 	}
-	if err := s.checkStatus(resp); err != nil {
+	if err = s.checkStatus(resp); err != nil {
 		return nil, err
 	}
 	s.hive.log.Printf("execute operation: %s; stmt: %s; status code: %s", guid(resp.OperationHandle.OperationId.GUID), stmt, resp.GetStatus().GetStatusCode())
@@ -81,7 +81,7 @@ func (s *Session) Close(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := s.checkStatus(resp); err != nil {
+	if err = s.checkStatus(resp); err != nil {
 		return err
 	}
 	return nil

--- a/internal/isql/connection.go
+++ b/internal/isql/connection.go
@@ -5,12 +5,10 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	"github.com/murfffi/gorich/helperr"
 	"github.com/sclgo/impala-go/internal/hive"
 )
 
@@ -19,39 +17,48 @@ var (
 	ErrNotSupported = errors.New("impala: not supported")
 )
 
-// Conn to impala. It is not used concurrently by multiple goroutines.
+// Conn to impala. It should not be used concurrently by multiple goroutines.
 type Conn struct {
-	transportCloser io.Closer
-	session         *hive.Session
-	client          *hive.Client
-	log             *log.Logger
+	transport thrift.TTransport // we use two methods: Close and IsOpen atm, make a dedicated iface if needed
+	session   *hive.Session
+	client    *hive.Client
+	log       *log.Logger
 }
+
+// This declaration lists and verifies driver interfaces implemented by *Conn
+var _ interface {
+	driver.Conn
+	driver.Pinger
+	driver.NamedValueChecker
+	driver.ConnPrepareContext
+	driver.QueryerContext
+	driver.ExecerContext
+	driver.SessionResetter
+	driver.Validator
+} = (*Conn)(nil)
 
 // Ping impala server
 // Implements driver.Pinger
 func (c *Conn) Ping(ctx context.Context) error {
-	session, err := c.OpenSession(ctx)
-	// returns err with ErrBadConn in chain if session is not already open and open fails
+	session, err := c.OpenSession(ctx) // also validates transport; err has driver.ErrBadConn in chain
 	if err != nil {
 		return err
 	}
 
-	err = session.Ping(ctx)
+	return mapErr(session.Ping(ctx))
+}
 
-	// Looking at go stdlib code, it seems that both "broken pipe" and "reset" are not
-	// specific error instances, so they can be checked only by message.
-	// Possibly, the reason is that those messages come from the OS.
-	if helperr.ContainsAny(err, "broken pipe", "connection reset by peer") {
-		err = fmt.Errorf("%w inferred from error: %v", driver.ErrBadConn, err)
-	}
-	// There can be other similar cases, but driver.ErrBadConn and Ping specs require us
-	// to only return it in chain if we are certain.
-	return err
+// isTransportOpen checks if the underlying connection is open without doing a roundtrip
+// and without blocking on IO. It can be used in cases where Ping will be too slow or unnecessary.
+func (c *Conn) isTransportOpen() bool {
+	// thrift implements that with a non-blocking peek of a byte over the socket
+	return c.transport.IsOpen()
 }
 
 // CheckNamedValue is called before passing arguments to the driver
 // and is called in place of any ColumnConverter. CheckNamedValue must do type
 // validation and conversion as appropriate for the driver.
+// Implements driver.NamedValueChecker
 func (c *Conn) CheckNamedValue(val *driver.NamedValue) error {
 	t, ok := val.Value.(time.Time)
 	if ok {
@@ -79,27 +86,29 @@ func (c *Conn) PrepareContext(_ context.Context, query string) (driver.Stmt, err
 // QueryContext executes a query that may return rows
 // Implements driver.QueryerContext
 func (c *Conn) QueryContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Rows, error) {
-	session, err := c.OpenSession(ctx)
+	session, err := c.OpenSession(ctx) // also validates transport; err has driver.ErrBadConn in chain
 	if err != nil {
 		return nil, err
 	}
 
 	tmpl := template(q)
 	stmt := statement(tmpl, args)
-	return query(ctx, session, stmt)
+	rows, err := query(ctx, session, stmt)
+	return rows, mapErr(err)
 }
 
 // ExecContext executes a query that doesn't return rows
 // Implements driver.ExecerContext
 func (c *Conn) ExecContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Result, error) {
-	session, err := c.OpenSession(ctx)
+	session, err := c.OpenSession(ctx) // also validates transport; err has driver.ErrBadConn in chain
 	if err != nil {
 		return nil, err
 	}
 
 	tmpl := template(q)
 	stmt := statement(tmpl, args)
-	return exec(ctx, session, stmt)
+	res, err := exec(ctx, session, stmt)
+	return res, mapErr(err)
 }
 
 // Begin is not supported
@@ -108,15 +117,24 @@ func (c *Conn) Begin() (driver.Tx, error) {
 	return nil, ErrNotSupported
 }
 
-// OpenSession ensure opened session
+// OpenSession ensures opened session and live transport connection
+// Any returned errors have driver.ErrBadConn in the chain
 func (c *Conn) OpenSession(ctx context.Context) (*hive.Session, error) {
 	if c.session == nil {
 		session, err := c.client.OpenSession(ctx)
 		if err != nil {
-			c.log.Printf("failed to open session: %v", err)
-			return nil, fmt.Errorf("%w inferred from error: %v", driver.ErrBadConn, err)
+			err = fmt.Errorf("%w: failed to open session: %v", driver.ErrBadConn, err)
+			c.log.Println(err)
+			return nil, err
 		}
 		c.session = session
+	} else {
+		// since we are just about to reuse the existing session, quickly check if the transport is still open,
+		// so we can return an error that database/sql/DB.retry can handle
+		// This check is on the hot path before any query so if it turns out to be too expensive it should be disabled.
+		if !c.isTransportOpen() {
+			return nil, fmt.Errorf("%w: underlying connection is not open", driver.ErrBadConn)
+		}
 	}
 	return c.session, nil
 }
@@ -126,6 +144,15 @@ func (c *Conn) OpenSession(ctx context.Context) (*hive.Session, error) {
 func (c *Conn) ResetSession(ctx context.Context) error {
 	if c.session != nil {
 		if err := c.session.Close(ctx); err != nil {
+			err = mapErr(err)
+
+			// database/sql uses ResetSession to validate a connection when taking it out of the pool,
+			// but it ignores errors other than ErrBadConn. As a precaution, we check again if the
+			// connection is open on the client, if we haven't mapped it to ErrBadConn already.
+
+			if !errors.Is(err, driver.ErrBadConn) && !c.isTransportOpen() {
+				err = fmt.Errorf("%w: underlying connection is not open after error %v while closing session", driver.ErrBadConn, err)
+			}
 			return err
 		}
 		c.session = nil
@@ -144,16 +171,26 @@ func (c *Conn) Close() error {
 		}
 	}
 
-	if err := c.transportCloser.Close(); err != nil {
+	if err := c.transport.Close(); err != nil {
 		return fmt.Errorf("failed to close underlying transport while closing connection: %w", err)
 	}
 	return nil
 }
 
+// IsValid checks that the connection is valid for use in database/sql
+// Implements driver.Validator
+// database/sql calls this before the connection is returned to the pool, after it has just been used.
+// In that case, running roundtrip validation like Ping is not worth the latency cost.
+// This method is reserved for use by database/sql only. Internal code should call isTransportOpen instead.
+// In the future, IsValid may do additional checks, not appropriate for other places isTransportOpen is called.
+func (c *Conn) IsValid() bool {
+	return c.isTransportOpen()
+}
+
 func NewConn(client *hive.Client, transport thrift.TTransport, logger *log.Logger) *Conn {
 	return &Conn{
-		transportCloser: transport,
-		client:          client,
-		log:             logger,
+		transport: transport,
+		client:    client,
+		log:       logger,
 	}
 }

--- a/internal/isql/errors.go
+++ b/internal/isql/errors.go
@@ -1,0 +1,34 @@
+package isql
+
+import (
+	"database/sql/driver"
+	"errors"
+	"fmt"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/murfffi/gorich/helperr"
+)
+
+func mapErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	var tErr thrift.TTransportException
+	if errors.As(err, &tErr) {
+		typeId := tErr.TypeId()
+		if typeId == thrift.NOT_OPEN || typeId == thrift.END_OF_FILE {
+			return fmt.Errorf("%w inferred from error: %v", driver.ErrBadConn, err)
+		}
+	}
+
+	// As a precaution, look for other indicators of ErrBadConn
+
+	// Looking at go stdlib code, it seems that both "broken pipe" and "reset" are not
+	// specific error instances, so they can be checked only by message.
+	// Possibly, the reason is that those messages come from the OS.
+	if helperr.ContainsAny(err, "broken pipe", "connection reset by peer") {
+		return fmt.Errorf("%w inferred from error: %v", driver.ErrBadConn, err)
+	}
+
+	return err
+}

--- a/internal/isql/errors_test.go
+++ b/internal/isql/errors_test.go
@@ -1,0 +1,71 @@
+package isql
+
+import (
+	"database/sql/driver"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapErr(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		require.NoError(t, mapErr(nil))
+	})
+
+	t.Run("returns original non bad connection error", func(t *testing.T) {
+		err := errors.New("some query error")
+
+		mappedErr := mapErr(err)
+
+		require.Same(t, err, mappedErr)
+		require.NotErrorIs(t, mappedErr, driver.ErrBadConn)
+	})
+
+	t.Run("maps thrift not open transport error to bad connection", func(t *testing.T) {
+		err := thrift.NewTTransportException(thrift.NOT_OPEN, "transport is not open")
+
+		mappedErr := mapErr(err)
+
+		require.ErrorIs(t, mappedErr, driver.ErrBadConn)
+		require.ErrorContains(t, mappedErr, "inferred from error")
+	})
+
+	t.Run("maps thrift end of file transport error to bad connection", func(t *testing.T) {
+		err := thrift.NewTTransportException(thrift.END_OF_FILE, io.EOF.Error())
+
+		mappedErr := mapErr(err)
+
+		require.ErrorIs(t, mappedErr, driver.ErrBadConn)
+		require.ErrorContains(t, mappedErr, "inferred from error")
+	})
+
+	t.Run("does not map other thrift transport errors to bad connection", func(t *testing.T) {
+		err := thrift.NewTTransportException(thrift.TIMED_OUT, "transport timed out")
+
+		mappedErr := mapErr(err)
+
+		require.Same(t, err, mappedErr)
+		require.NotErrorIs(t, mappedErr, driver.ErrBadConn)
+	})
+
+	t.Run("maps broken pipe error message to bad connection", func(t *testing.T) {
+		err := errors.New("write tcp: broken pipe")
+
+		mappedErr := mapErr(err)
+
+		require.ErrorIs(t, mappedErr, driver.ErrBadConn)
+		require.ErrorContains(t, mappedErr, "inferred from error")
+	})
+
+	t.Run("maps connection reset error message to bad connection", func(t *testing.T) {
+		err := errors.New("read tcp: connection reset by peer")
+
+		mappedErr := mapErr(err)
+
+		require.ErrorIs(t, mappedErr, driver.ErrBadConn)
+		require.ErrorContains(t, mappedErr, "inferred from error")
+	})
+}


### PR DESCRIPTION
The driver now returns driver.ErrBadConn in all required cases. With this, database/sql.DB methods correctly retry getting connections out of the pool and are more likely to succeed if there are intermittent connection issues.

The fix allowed workarounds in TestIntegration_Restart to be removed.

The PR also includes minor unrelated documentation and testing improvements for handling SET statements. 