### PR TITLE
feat: extend connection validation to TLS connections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Test
       run: |
-        make test
+        make test-all
 
     - name: Checks
       run: |
@@ -59,7 +59,25 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Test
-        run: make short-test
+        run: make test vet-func-test
+
+  ci-other-os:
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.10"
+
+      - name: Test
+        run: make test vet-func-test
 
   post-merge:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -17,21 +17,28 @@ thrift:
 cli: usql
 
 usql: Makefile
-	go run github.com/sclgo/usqlgen@v0.3.0 -v build --get github.com/sclgo/impala-go@$(shell git branch --show-current || echo master) -- -tags impala
+	go run github.com/sclgo/usqlgen@v0.8.0 -v build --get github.com/sclgo/impala-go@$(shell git branch --show-current || echo master) -- -tags impala
 
 .PHONY: short-test
 short-test:
 	go test -short -v -vet=all ./...
-	cd functest && go test -c -vet=all ./...
 
 .PHONY: test-cli
 test-cli: usql
 	./usql -c "\drivers" | grep impala
 
 .PHONY: test
+test:
+	go test -v -vet=all ./...
+
+.PHONY: vet-func-test
+vet-func-test:
+	cd functest && go test -c -vet=all ./...
+
+.PHONY: test-all
 PKGS=$(shell go list ./... | grep -v "./internal/generated" | grep -v "./examples")
 PKGS_LST=$(shell echo ${PKGS} | tr ' ' ',')
-test: tools/ts
+test-all: tools/ts vet-func-test
 	rm -fr coverage/covdata
 	mkdir -p coverage/covdata
 # Use the new binary format to ensure integration tests and cross-package calls are counted towards coverage

--- a/augmented_tls_conn.go
+++ b/augmented_tls_conn.go
@@ -1,0 +1,33 @@
+package impala
+
+import (
+	"crypto/tls"
+	"net"
+	"syscall"
+)
+
+func augment(conn net.Conn) net.Conn {
+	tlsConn, ok := conn.(*tls.Conn)
+	if ok {
+		if _, ok = tlsConn.NetConn().(syscall.Conn); ok {
+			return augmentedTlsConn{tlsConn}
+		}
+	}
+	return conn
+}
+
+// augmentedTlsConn implements interface syscall.Conn on *tls.Conn
+// so the new conn can be used in Thrift socketConn.checkConn() on Unix
+type augmentedTlsConn struct {
+	*tls.Conn
+}
+
+func (a augmentedTlsConn) SyscallConn() (syscall.RawConn, error) {
+	conn := a.NetConn()
+	return conn.(syscall.Conn).SyscallConn()
+}
+
+var _ interface {
+	syscall.Conn
+	net.Conn
+} = augmentedTlsConn{}

--- a/augmented_tls_conn_test.go
+++ b/augmented_tls_conn_test.go
@@ -1,0 +1,17 @@
+package impala
+
+import (
+	"crypto/tls"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAugment(t *testing.T) {
+	tlsConn := tls.Client(&net.TCPConn{}, nil)
+	require.NotImplements(t, (*syscall.Conn)(nil), tlsConn)
+	conn := augment(tlsConn)
+	require.Implements(t, (*syscall.Conn)(nil), conn)
+}

--- a/driver.go
+++ b/driver.go
@@ -327,7 +327,7 @@ func openTransport(ctx context.Context, opts *Options) (thrift.TTransport, *thri
 
 		err = transport.Open()
 		if err != nil {
-			return nil, nil, fmt.Errorf("impala: authentication failed: %w", err)
+			return nil, nil, fmt.Errorf("%w: authentication failed: %w", ErrOpenFailed, err)
 		}
 	} else {
 		transport = thrift.NewTBufferedTransport(transport, opts.BufferSize)

--- a/driver.go
+++ b/driver.go
@@ -23,40 +23,46 @@ import (
 	"github.com/sclgo/impala-go/internal/sasl"
 )
 
-// Sentinel errors returned by the driver
+// Custom sentinel errors returned by the driver
 
 var (
 	// ErrNotSupported means the driver does not support this operation
 	ErrNotSupported = isql.ErrNotSupported
+
+	// ErrOpenFailed means the driver failed to open a connection.
+	// Following database/sql docs, this is a separate error from driver.ErrBadConn.
+	// If the root cause is context.DeadlineExceeded, AuthError, or *tls.CertificateVerificationError,
+	// that cause will be in the same error tree as this sentinel, likely as a sibling.
+	ErrOpenFailed = errors.New("impala: failed to open connection")
+
+	// ErrBadDSN means the driver failed to parse the DSN or contained incorrect values.
+	// Another error in the tree will describe the specific issue.
+	ErrBadDSN = errors.New("impala: bad DSN")
 )
 
-// The following errors carry instance information, so they are types, instead of sentinel values.
+// Custom error types returned by the driver
 
 // AuthError indicates that there was an authentication or authorization failure.
 // The error message documents the username used, if any.
 // errors.Unwrap() returns the underlying error interpreted as auth. failure, if any.
-// This error will not be top-level in the chain - earlier errors in the chain
-// reflect the process during which the auth. error happened.
+// This error will not be top-level in the chain/tree - earlier errors
+// reflect the process during which the error happened.
 type AuthError = sasl.AuthError
-
-const (
-	badDSNErrorPrefix = "impala: bad DSN: "
-)
 
 // Driver to impala
 type Driver struct{}
 
-// Open creates new connection to impala using the given data source name. Implements driver.Driver.
-// Returned error wraps any errors coming from thrift or stdlib - typically crypto or net packages.
-// If TLS is requested, and the server certificate fails validation, the error chain includes *tls.CertificateVerificationError
-// If there was an authentication error, an error chain includes one of the exported auth. errors in this package.
+// Open creates a new connection to impala using the given data source name. Implements driver.Driver.
+// The returned error contains ErrOpenFailed in the chain/tree, along with the specific cause.
+// See ErrOpenFailed about which causes are guaranteed to be reported.
+// The API does not guarantee the order of errors in the tree.
 func (d *Driver) Open(dsn string) (driver.Conn, error) {
 	opts, err := parseURI(dsn)
 	if err != nil {
-		return nil, fmt.Errorf(badDSNErrorPrefix+"%w", err)
+		return nil, fmt.Errorf("%w: %w", ErrBadDSN, err)
 	}
 
-	conn, err := connect(opts)
+	conn, err := connect(context.Background(), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -224,9 +230,9 @@ func NewConnector(opts *Options) driver.Connector {
 
 // Connect implements driver.Connector
 // See Driver.Open for details about error results
-func (c *connector) Connect(context.Context) (driver.Conn, error) {
+func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	// TTransport.Open doesn't support context. In general, Thrift almost always doesn't accept or ignores context.
-	return connect(c.opts)
+	return connect(ctx, c.opts)
 }
 
 // Driver implements driver.Connector
@@ -234,11 +240,11 @@ func (c *connector) Driver() driver.Driver {
 	return c.d
 }
 
-func connect(opts *Options) (*isql.Conn, error) {
+func connect(ctx context.Context, opts *Options) (*isql.Conn, error) {
 	if opts.LogOut == nil {
 		opts.LogOut = io.Discard
 	}
-	transport, tclient, err := connectThrift(opts)
+	transport, tclient, err := connectThrift(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -255,45 +261,59 @@ func connect(opts *Options) (*isql.Conn, error) {
 	}), nil
 }
 
-func configureTransport(opts *Options) (thrift.TTransport, *tls.Config, error) {
-	addr := net.JoinHostPort(opts.Host, opts.Port)
+func openTransport(ctx context.Context, opts *Options) (thrift.TTransport, *thrift.TConfiguration, error) {
+	var err error
+	hostPort := net.JoinHostPort(opts.Host, opts.Port)
 
-	var socket thrift.TTransport
-	var tlsConf *tls.Config
-	if opts.UseTLS {
-
-		tlsConf = &tls.Config{
-			InsecureSkipVerify: opts.TLSInsecureSkipVerify,
-		}
-		if certPath := opts.CACertPath; certPath != "" {
-			caCertPool, err := readCert(certPath)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to read CA certificate: %w", err)
-			}
-			tlsConf.RootCAs = caCertPool
-		}
-		// otherwise "host's root CA set" is used
-
-		// Configuration applied in protocol below
-		socket = thrift.NewTSSLSocketConf(addr, &thrift.TConfiguration{
-			// should generally be overwritten but setting just in case to avoid regressions like #50
-			TLSConfig: tlsConf,
-		})
-	} else {
-		socket = thrift.NewTSocketConf(addr, &thrift.TConfiguration{})
+	conf := &thrift.TConfiguration{
+		TBinaryStrictRead:  lo.ToPtr(false),
+		TBinaryStrictWrite: lo.ToPtr(true),
+		SocketTimeout:      opts.SocketTimeout,
+		ConnectTimeout:     opts.ConnectTimeout,
 	}
 
 	var transport thrift.TTransport
-	var err error
+	if opts.UseTLS {
+
+		conf.TLSConfig, err = getTLSConfig(opts)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		dialer := tls.Dialer{
+			NetDialer: &net.Dialer{
+				Timeout: conf.GetConnectTimeout(),
+			},
+			Config: conf.TLSConfig,
+		}
+
+		conn, err := dialer.DialContext(ctx, "tcp", hostPort)
+		if err != nil {
+			var addInfo string
+			if opts.systemCAStoreSelected() {
+				addInfo = " (using system root CAs)"
+			}
+			return nil, nil, wrapConnectErr(ctx, err, addInfo)
+		}
+		conn = augment(conn)
+		transport = thrift.NewTSSLSocketFromConnConf(conn, conf)
+		// this transport is open
+	} else {
+		transport = thrift.NewTSocketConf(hostPort, conf)
+		if err := transport.Open(); err != nil {
+			return nil, nil, wrapConnectErr(ctx, err, "")
+		}
+	}
+
 	if opts.UseLDAP {
 
 		if opts.Username == "" {
-			return nil, nil, errors.New("provide username for LDAP auth")
+			return nil, nil, fmt.Errorf("%w: provide username for LDAP auth", ErrBadDSN)
 		}
 
 		// Empty password will be used if not provided.
 
-		transport, err = sasl.NewTSaslTransport(socket, &sasl.Options{
+		transport, err = sasl.NewTSaslTransport(transport, &sasl.Options{
 			Host:     opts.Host,
 			Username: opts.Username,
 			Password: opts.Password,
@@ -304,11 +324,40 @@ func configureTransport(opts *Options) (thrift.TTransport, *tls.Config, error) {
 			// NewTSaslTransport always returns nil error
 			return nil, nil, err
 		}
+
+		err = transport.Open()
+		if err != nil {
+			return nil, nil, fmt.Errorf("impala: authentication failed: %w", err)
+		}
 	} else {
-		transport = thrift.NewTBufferedTransport(socket, opts.BufferSize)
+		transport = thrift.NewTBufferedTransport(transport, opts.BufferSize)
 	}
 
-	return transport, tlsConf, nil
+	return transport, conf, nil
+}
+
+func getTLSConfig(opts *Options) (*tls.Config, error) {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: opts.TLSInsecureSkipVerify,
+	}
+	if certPath := opts.CACertPath; !opts.TLSInsecureSkipVerify && certPath != "" {
+		caCertPool, err := readCert(certPath)
+		if err != nil {
+			return nil, fmt.Errorf("%w: failed to read CA certificate: %w", ErrBadDSN, err)
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+	return tlsConfig, nil
+}
+func wrapConnectErr(ctx context.Context, err error, addInfo string) error {
+	// Add information so the user can tell if "context deadline exceeded" means that
+	// the ConnectTimeout was exceeded or the deadline was from the given context.
+	// Internally, net.DialContext implements ConnectTimeout with a child context.
+	if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+		// full message will be something like "connect timeout: context deadline exceeded"
+		addInfo += " connect timeout context:"
+	}
+	return fmt.Errorf("%w:%s %w", ErrOpenFailed, addInfo, err)
 }
 
 func readCert(certPath string) (*x509.CertPool, error) {
@@ -325,29 +374,13 @@ func readCert(certPath string) (*x509.CertPool, error) {
 	return caCertPool, nil
 }
 
-func connectThrift(opts *Options) (thrift.TTransport, thrift.TClient, error) {
-	transport, tlsConf, err := configureTransport(opts)
-	if err != nil {
-		return nil, nil, fmt.Errorf(badDSNErrorPrefix+"%w", err)
-	}
+func connectThrift(ctx context.Context, opts *Options) (thrift.TTransport, thrift.TClient, error) {
+	transport, conf, err := openTransport(ctx, opts)
 
-	protocol := thrift.NewTBinaryProtocolConf(transport, &thrift.TConfiguration{
-		// The following configuration is propagated to Transport / Socket
-		TBinaryStrictRead:  lo.ToPtr(false),
-		TBinaryStrictWrite: lo.ToPtr(true),
-		TLSConfig:          tlsConf,
-		SocketTimeout:      opts.SocketTimeout,
-		ConnectTimeout:     opts.ConnectTimeout,
-	})
-	// the transport has been modified by the binary protocol, propagating configuration
-	// we can now Open it
-	if err = transport.Open(); err != nil {
-		addInfo := ""
-		if tlsConf != nil && tlsConf.RootCAs == nil {
-			addInfo = " using system root CAs"
-		}
-		return nil, nil, fmt.Errorf("impala: failed to open connection%s: %w", addInfo, err)
+	if err != nil {
+		return nil, nil, err
 	}
+	protocol := thrift.NewTBinaryProtocolConf(transport, conf)
 
 	tclient := thrift.NewTStandardClient(protocol, protocol)
 	return transport, tclient, nil

--- a/driver_test.go
+++ b/driver_test.go
@@ -2,6 +2,7 @@ package impala
 
 import (
 	"context"
+	"database/sql/driver"
 	"fmt"
 	"net"
 	"strconv"
@@ -88,43 +89,79 @@ func TestParseURI_Negative(t *testing.T) {
 	drv := &Driver{}
 	t.Run("scheme", func(t *testing.T) {
 		_, err := drv.Open("notimpala://")
-		require.ErrorContains(t, err, badDSNErrorPrefix)
+		require.ErrorIs(t, err, ErrBadDSN)
 		require.ErrorContains(t, err, "notimpala")
 	})
 	t.Run("invalidurl", func(t *testing.T) {
 		_, err := drv.Open("impala://user:pass???@localhost")
-		require.ErrorContains(t, err, badDSNErrorPrefix)
+		require.ErrorIs(t, err, ErrBadDSN)
 		require.ErrorContains(t, err, "parse")
 	})
 	for _, key := range []string{"batch-size", "buffer-size", "query-timeout", "tls", "socket-timeout", "connect-timeout"} {
 		t.Run("invalid "+key, func(t *testing.T) {
 			_, err := drv.Open(fmt.Sprintf("impala://localhost?%s=aa", key))
-			require.ErrorContains(t, err, badDSNErrorPrefix)
+			require.ErrorIs(t, err, ErrBadDSN)
 			require.ErrorContains(t, err, "invalid "+key)
 		})
 	}
 	t.Run("invalid ca-cert", func(t *testing.T) {
 		_, err := drv.Open("impala://localhost?tls=true&ca-cert=aa")
-		require.ErrorContains(t, err, badDSNErrorPrefix)
+		require.ErrorIs(t, err, ErrBadDSN)
 		require.ErrorContains(t, err, "certificate")
 	})
 }
 
 func TestDriver_Integration(t *testing.T) {
 	fi.SkipLongTest(t)
-	t.Run("openUnresponsive", func(t *testing.T) {
-		port := createUnresponsiveSocket(t)
 
-		opts := &Options{
-			Host:          "localhost",
-			Port:          strconv.Itoa(port),
-			SocketTimeout: time.Second,
-		}
-		conn, err := connect(opts)
-		require.NoError(t, err)
-		_, err = conn.OpenSession(context.Background()) // thrift ignores context anyway in most cases
-		require.ErrorContains(t, err, "bad connection")
+	port := createUnresponsiveSocket(t)
+	t.Run("openUnresponsive", func(t *testing.T) {
+		t.Run("plainSocketTimeout", func(t *testing.T) {
+			opts := &Options{
+				Host:          "localhost",
+				Port:          strconv.Itoa(port),
+				SocketTimeout: 100 * time.Millisecond,
+			}
+			conn, err := connect(context.Background(), opts)
+			require.NoError(t, err)
+			_, err = conn.OpenSession(context.Background()) // thrift ignores context in most cases
+			require.ErrorIs(t, err, driver.ErrBadConn)
+		})
+
+		t.Run("tlsCtx", func(t *testing.T) {
+			opts := &Options{
+				Host:   "localhost",
+				Port:   strconv.Itoa(port),
+				UseTLS: true,
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			_, err := connect(ctx, opts)
+			require.ErrorIs(t, err, ErrOpenFailed)
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+		})
+
+		// connect timeout is tested with TLS because, for plain sockets, that timeout
+		// impacts only the initial TCP handshake. it is hard to create a test socket that
+		// does that slowly enough.
+
+		t.Run("tlsConnectTimeout", func(t *testing.T) {
+			opts := &Options{
+				Host:           "localhost",
+				Port:           strconv.Itoa(port),
+				UseTLS:         true,
+				ConnectTimeout: 100 * time.Millisecond,
+			}
+			_, err := connect(context.Background(), opts)
+			t.Log(err)
+			require.ErrorIs(t, err, ErrOpenFailed)
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+			// in this case, the context that exceeded its deadline was created in
+			// one of the variants of net.Dial
+			require.ErrorContains(t, err, "connect timeout")
+		})
 	})
+
 }
 
 func createUnresponsiveSocket(t *testing.T) int {

--- a/functest/connection_test.go
+++ b/functest/connection_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -220,21 +221,21 @@ func TestIntegration_Impala4Restart(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		perr := db.PingContext(ctx)
-		//if perr != nil {
-		//	require.ErrorIs(t, perr, driver.ErrBadConn)
-		//}
+		if perr != nil && !errors.Is(perr, impala.ErrOpenFailed) {
+			require.ErrorIs(t, perr, driver.ErrBadConn)
+		}
 		t.Log(perr)
 		return perr == nil
 	}, 2*time.Minute, 2*time.Second)
 
-	//// the conn that we took out of the pool before restart should still be bad even after Impala is back up
-	//err = conn.PingContext(ctx)
-	//require.ErrorIs(t, err, driver.ErrBadConn)
-	//
-	//// Ping on the second pool should succeed even though that pool contains connections that are broken
-	//// because of successful connection verification inside database/sql
-	//err = db2.PingContext(ctx)
-	//require.NoError(t, err)
+	// the conn that we took out of the pool before restart should still be bad even after Impala is back up
+	err = conn.PingContext(ctx)
+	require.ErrorIs(t, err, driver.ErrBadConn)
+
+	// Ping on the second pool should succeed even though that pool contains connections that are broken
+	// because of successful connection verification inside database/sql
+	err = db2.PingContext(ctx)
+	require.NoError(t, err)
 }
 
 func runSuite(t *testing.T, dsn string) {

--- a/impala.go
+++ b/impala.go
@@ -65,6 +65,10 @@ type Options struct {
 	ConnectTimeout time.Duration
 }
 
+func (o *Options) systemCAStoreSelected() bool {
+	return o.CACertPath == "" && !o.TLSInsecureSkipVerify
+}
+
 var (
 	// DefaultOptions for impala driver
 	DefaultOptions = Options{


### PR DESCRIPTION
This change moves dialing from Thrift into the driver for TLS connections. This allows us to inject a workaround for the Thrift deficiency which breaks connection validation on TLS connections. The new dialing code also supports context, so context is respected in Connector.Connect but only in case of TLS.

 The PR also exposes two new sentinel errors sentinel errors (ErrOpenFailed and ErrBadDSN).

CI testing is extended to windows because the library started using unix only behavior - connection check - in #98 . 

Closes #105 